### PR TITLE
Bump datadog version, add missing python wheel pkg

### DIFF
--- a/datadog/Dockerfile.template
+++ b/datadog/Dockerfile.template
@@ -24,8 +24,10 @@ FROM balenalib/%%BALENA_MACHINE_NAME%%-debian
 WORKDIR /usr/app
 
 COPY --from=build ./usr/app/src/github.com/DataDog/datadog-agent/bin/ /usr/app/build/
+COPY --from=build /usr/app/src/github.com/DataDog/datadog-agent/rtloader/include/ /usr/include/
+COPY --from=build /usr/app/src/github.com/DataDog/datadog-agent/rtloader/rtloader/libdatadog-agent-rtloader.so.0.1.0 /usr/lib/
 COPY files /usr/app/files
-RUN chmod +x files/start.sh
+RUN chmod +x files/start.sh && ldconfig
 
 RUN ln -s /usr/app/build/agent/dist/ /etc/datadog-agent
 

--- a/datadog/Dockerfile.template
+++ b/datadog/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM balenalib/%%BALENA_MACHINE_NAME%%-golang:latest-build AS build
 
-RUN install_packages sysstat python python-dev python-pip libpython-dev python-setuptools git
+RUN install_packages sysstat python python-dev python-pip libpython-dev python-setuptools git libkrb5-dev build-essential
 
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
@@ -8,13 +8,15 @@ RUN pip install -r requirements.txt
 ENV GOPATH=/usr/app
 ENV PATH=$PATH:/usr/app/bin
 
-RUN git clone --branch 6.8.3 --depth 1 https://github.com/DataDog/datadog-agent.git /usr/app/src/github.com/DataDog/datadog-agent
+RUN git clone --branch 6.13.0 --depth 1 https://github.com/DataDog/datadog-agent.git /usr/app/src/github.com/DataDog/datadog-agent
 
 WORKDIR /usr/app/src/github.com/DataDog/datadog-agent
 
 RUN export PATH=$PATH:$GOPATH/bin && \
   cd /usr/app/src/github.com/DataDog/datadog-agent && \
-  invoke deps && \
+  invoke deps -v
+
+RUN invoke rtloader.build && invoke rtloader.install && \
   invoke agent.build --build-exclude=snmp,systemd
 
 FROM balenalib/%%BALENA_MACHINE_NAME%%-debian

--- a/datadog/Dockerfile.template
+++ b/datadog/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM balenalib/%%BALENA_MACHINE_NAME%%-golang:latest-build AS build
 
-RUN install_packages sysstat python python-dev python-pip libpython-dev python-setuptools git libkrb5-dev build-essential
+RUN install_packages sysstat python python-dev python-pip libpython-dev python-setuptools git libkrb5-dev cmake
 
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt

--- a/datadog/requirements.txt
+++ b/datadog/requirements.txt
@@ -5,3 +5,4 @@ docker==3.0.1
 requests==2.20.1
 PyYAML==4.2b1
 toml==0.9.4
+wheel==0.33.4


### PR DESCRIPTION
This bumps datadog to its [current release](https://github.com/DataDog/datadog-agent/releases/tag/6.13.0), 6.13.0, adding the `rtloader` build step accordingly. 