### PR TITLE
datadog: Dockerfile.template: use go netdns resolver

### DIFF
--- a/datadog/Dockerfile.template
+++ b/datadog/Dockerfile.template
@@ -22,7 +22,7 @@ RUN git clone --branch 7.25.1 --depth 1 https://github.com/DataDog/datadog-agent
 
 WORKDIR /usr/app/src/github.com/DataDog/datadog-agent
 
-RUN export PATH=$PATH:$GOPATH/bin && \
+RUN export PATH=$PATH:$GOPATH/bin GODEBUG=netdns=go && \
   cd /usr/app/src/github.com/DataDog/datadog-agent && \
   invoke deps -v
 


### PR DESCRIPTION
The cgo resolver causes TLS handshake timeouts occasionally. Docker will
sometimes choose to use this resolver instead of the newer, pure Go
resolver, and it seems this is the case when building in Docker.

More information here: https://golang.org/pkg/net/

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>